### PR TITLE
feat: Expose generated files for reuse

### DIFF
--- a/src/actions/dev-action.yml
+++ b/src/actions/dev-action.yml
@@ -1,7 +1,8 @@
-# This assumes the action is run from a repo that has the CLI as a dependency
-# or is the CLI repo itself.
-name: 'Xano Community CLI Action'
-description: 'Sets up and runs a Xano Community CLI command in a GitHub workflow.'
+# This assumes the action is run from a repo that has the CLI as a dependency,
+# or is the CLI repo itself (not npm-installed).
+
+name: 'Xano Community CLI Dev Action'
+description: 'Sets up and runs a Xano Community CLI command in a GitHub workflow (dev/local version).'
 author: 'Xano Community'
 
 inputs:
@@ -18,6 +19,10 @@ inputs:
       description: 'The Xano Metadata API token. Should be stored as a GitHub secret.'
       required: true
 
+outputs:
+   output-dirs:
+      description: 'Newline-separated list of output directories'
+
 runs:
    using: 'composite'
    steps:
@@ -26,28 +31,45 @@ runs:
         run: npm install
 
       - name: Configure Xano CLI Instance
+        id: configure_cli
         shell: bash
         run: |
+           set -e
+           echo "::group::Configuring Xano CLI Instance"
            node src/index.js setup \
              --name "${{ inputs.instance-name }}" \
              --url "${{ inputs.instance-url }}" \
              --token "${{ inputs.api-token }}" \
              --no-set-current
+           echo "::endgroup::"
 
-      - name: Run Xano CLI Commands
+      - name: Run Xano CLI Commands and Collect Outputs
+        id: run_cli
         shell: bash
         run: |
-           # Ensure the script exits immediately if any command fails.
            set -e
-
-           # The user provides a multi-line string of commands.
-           # We execute them one by one. The 'set -e' default for shell steps
-           # will cause the script to exit on the first failure.
+           OUTPUT_DIRS=""
            while IFS= read -r command_line; do
              if [ -z "$command_line" ]; then
                continue # Skip empty lines
              fi
              echo "::group::Running: xcc $command_line"
-             node src/index.js $command_line --instance=${{ inputs.instance-name }}
+             OUTPUT=$(node src/index.js $command_line --instance="${{ inputs.instance-name }}" --print-output-dir)
+             DIRS=$(echo "$OUTPUT" | grep 'OUTPUT_DIR=' | cut -d'=' -f2-)
+             if [ -n "$DIRS" ]; then
+               OUTPUT_DIRS="${OUTPUT_DIRS}${DIRS}"$'\n'
+             fi
              echo "::endgroup::"
            done <<< "${{ inputs.run }}"
+           OUTPUT_DIRS=$(echo -n "$OUTPUT_DIRS")
+           echo "output-dirs<<EOF" >> $GITHUB_OUTPUT
+           echo "$OUTPUT_DIRS" >> $GITHUB_OUTPUT
+           echo "EOF" >> $GITHUB_OUTPUT
+
+      # Example usage in your workflow:
+      # - name: Upload all generated code as artifact
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: generated-code
+      #     path: |
+      #       ${{ steps.xano.outputs.output-dirs }}

--- a/src/actions/master-action.yml
+++ b/src/actions/master-action.yml
@@ -1,5 +1,5 @@
 # This action assumes that the XCC is already an NPM package and can be used
-# from a registry. Which is not the case yet.
+# from a registry. Which is not the case yet.name: 'Xano Community CLI Action'
 name: 'Xano Community CLI Action'
 description: 'Sets up and runs a Xano Community CLI command in a GitHub workflow.'
 author: 'Xano Community'
@@ -22,10 +22,15 @@ inputs:
       required: false
       default: 'latest'
 
+outputs:
+   output-dirs:
+      description: 'Newline-separated list of output directories'
+
 runs:
    using: 'composite'
    steps:
       - name: Configure Xano CLI Instance
+        id: configure_cli
         shell: bash
         run: |
            # Ensure the script exits immediately if any command fails.
@@ -41,16 +46,36 @@ runs:
              --no-set-current
            echo "::endgroup::"
 
-      - name: Run Xano CLI Commands
+      - name: Run Xano CLI Commands and Collect Outputs
+        id: run_cli
         shell: bash
         run: |
            set -e
+           # Prepare the output collection variable.
+           OUTPUT_DIRS=""
            # The setup command has created the config files. Now, run the user-provided commands.
            while IFS= read -r command_line; do
              if [ -z "$command_line" ]; then
                continue # Skip empty lines
              fi
              echo "::group::Running: xcc $command_line"
-             npx --yes @mihalytoth20/xano-community-cli@${{ inputs.version }} $command_line --instance=${{ inputs.instance-name }}
+             OUTPUT=$(npx --yes @mihalytoth20/xano-community-cli@${{ inputs.version }} $command_line --instance=${{ inputs.instance-name }} --print-output-dir)
+             DIRS=$(echo "$OUTPUT" | grep 'OUTPUT_DIR=' | cut -d'=' -f2-)
+             if [ -n "$DIRS" ]; then
+               OUTPUT_DIRS="${OUTPUT_DIRS}${DIRS}"$'\n'
+             fi
              echo "::endgroup::"
            done <<< "${{ inputs.run }}"
+           # Remove trailing newline for clean output
+           OUTPUT_DIRS=$(echo -n "$OUTPUT_DIRS")
+           echo "output-dirs<<EOF" >> $GITHUB_OUTPUT
+           echo "$OUTPUT_DIRS" >> $GITHUB_OUTPUT
+           echo "EOF" >> $GITHUB_OUTPUT
+
+      # Example usage in your workflow:
+      # - name: Upload all generated code as artifact
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: generated-code
+      #     path: |
+      #       ${{ steps.xano.outputs.output-dirs }}

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -10,9 +10,11 @@ import {
    replacePlaceholders,
    sanitizeFileName,
    addFullContextOptions,
+   addPrintOutputFlag,
+   printOutputDir,
 } from '../utils/index';
 
-async function fetchFunctionsInXanoScript(instance, workspace, branch) {
+async function fetchFunctionsInXanoScript(instance, workspace, branch, printOutput = false) {
    intro('Starting to analyze functions.');
    let branchFunctions = {};
    const { instanceConfig, workspaceConfig, branchConfig } = loadAndValidateContext({
@@ -92,6 +94,7 @@ async function fetchFunctionsInXanoScript(instance, workspace, branch) {
    }
 
    outro('Analysis completed.');
+   printOutputDir(printOutput, outputDir);
 }
 
 function registerFetchFunctionsInXanoScript(program) {
@@ -100,10 +103,15 @@ function registerFetchFunctionsInXanoScript(program) {
       .description('Analyze the functions available in the current (or provided) context.');
 
    addFullContextOptions(cmd);
-
+   addPrintOutputFlag(cmd);
    cmd.action(
       withErrorHandler(async (opts) => {
-         await fetchFunctionsInXanoScript(opts.instance, opts.workspace, opts.branch);
+         await fetchFunctionsInXanoScript(
+            opts.instance,
+            opts.workspace,
+            opts.branch,
+            opts.printOutputDir
+         );
       })
    );
 }

--- a/src/commands/backups.ts
+++ b/src/commands/backups.ts
@@ -12,9 +12,11 @@ import {
    metaApiRequestBlob,
    replacePlaceholders,
    withErrorHandler,
+   printOutputDir,
+   addPrintOutputFlag,
 } from '../utils/index';
 
-async function exportBackup(instance, workspace, branch) {
+async function exportBackup(instance, workspace, branch, printOutput = false) {
    const { instanceConfig, workspaceConfig, branchConfig } = loadAndValidateContext({
       instance,
       workspace,
@@ -55,6 +57,7 @@ async function exportBackup(instance, workspace, branch) {
    writeFileSync(backupPath, backupBuffer);
 
    s.stop(`Workspace backup saved -> ${backupPath}`);
+   printOutputDir(printOutput, outputDir);
 }
 
 async function restoreBackup(instance, workspace, sourceBackup = null, forceConfirm = false) {
@@ -170,6 +173,7 @@ function registerExportBackupCommand(program) {
       .description('Backup Xano Workspace via Metadata API');
 
    addFullContextOptions(cmd);
+   addPrintOutputFlag(cmd);
 
    cmd.action(
       withErrorHandler(async (options) => {

--- a/src/commands/generate-code.ts
+++ b/src/commands/generate-code.ts
@@ -3,10 +3,12 @@ import { loadToken } from '../config/loaders';
 import {
    addApiGroupOptions,
    addFullContextOptions,
+   addPrintOutputFlag,
    chooseApiGroupOrAll,
    loadAndValidateContext,
    metaApiGet,
    normalizeApiGroupName,
+   printOutputDir,
    replacePlaceholders,
    withErrorHandler,
 } from '../utils/index';
@@ -18,13 +20,14 @@ async function generateCodeFromOas(
    instance,
    workspace,
    branch,
-   group,
-   isAll = false,
-   stack = {
+   group: string,
+   isAll: boolean = false,
+   stack: { generator: string; args: string[] } = {
       generator: 'typescript-fetch',
       args: ['--additional-properties=supportsES6=true'],
    },
-   logger = false
+   logger: boolean = false,
+   printOutput: boolean = false
 ) {
    const startTime: Date = new Date();
    intro('🔄 Starting to generate code');
@@ -33,7 +36,6 @@ async function generateCodeFromOas(
       instance,
       workspace,
       branch,
-      group,
    });
    // Determine generator and extra args
    const generator = stack.generator || 'typescript-fetch';
@@ -81,6 +83,7 @@ async function generateCodeFromOas(
             logger,
          });
          s.stop(`Code generated for group "${group.name}" → ${outputPath}/codegen/${generator}`);
+         printOutputDir(printOutput, outputPath);
       } catch (err) {
          s.stop();
          log.error(err.message);
@@ -101,6 +104,7 @@ function registerGenerateCodeCommand(program) {
 
    addFullContextOptions(cmd);
    addApiGroupOptions(cmd);
+   addPrintOutputFlag(cmd);
 
    cmd.option(
       '--generator <generator>',
@@ -133,7 +137,8 @@ function registerGenerateCodeCommand(program) {
                opts.group,
                opts.all,
                stack,
-               opts.debug
+               opts.debug,
+               opts.printOutput
             );
          })
       );

--- a/src/commands/generate-oas.ts
+++ b/src/commands/generate-oas.ts
@@ -3,13 +3,21 @@ import { loadToken } from '../config/loaders';
 import {
    addApiGroupOptions,
    addFullContextOptions,
+   addPrintOutputFlag,
    chooseApiGroupOrAll,
    loadAndValidateContext,
    withErrorHandler,
 } from '../utils/index';
 import { updateSpecForGroup } from '../features/oas/generate/index';
 
-async function updateOpenapiSpec(instance, workspace, branch, group, isAll) {
+async function updateOpenapiSpec(
+   instance: string,
+   workspace: string,
+   branch: string,
+   group: string,
+   isAll: boolean,
+   printOutput: boolean = false
+) {
    intro('🔄 Starting to generate OpenAPI specifications.');
    try {
       const { instanceConfig, workspaceConfig, branchConfig } = loadAndValidateContext({
@@ -36,6 +44,7 @@ async function updateOpenapiSpec(instance, workspace, branch, group, isAll) {
             instanceConfig,
             workspaceConfig,
             branchConfig,
+            printOutput,
          });
       }
       outro('All OpenAPI specifications generated.');
@@ -51,6 +60,7 @@ function registerGenerateOasCommand(program) {
 
    addFullContextOptions(cmd);
    addApiGroupOptions(cmd);
+   addPrintOutputFlag(cmd);
 
    cmd.action(
       withErrorHandler(async (opts) => {

--- a/src/commands/generate-repo.ts
+++ b/src/commands/generate-repo.ts
@@ -2,14 +2,24 @@ import { mkdir } from 'fs/promises';
 import { loadToken } from '../config/loaders';
 import {
    addFullContextOptions,
+   addPrintOutputFlag,
    fetchAndExtractYaml,
    loadAndValidateContext,
+   printOutputDir,
    replacePlaceholders,
    withErrorHandler,
 } from '../utils/index';
 import { processWorkspace } from '../features/process-xano/index';
 
-async function generateRepo(instance, workspace, branch, input, output, fetch = false) {
+async function generateRepo(
+   instance,
+   workspace,
+   branch,
+   input,
+   output,
+   fetch = false,
+   printOutput = false
+) {
    const { instanceConfig, workspaceConfig, branchConfig } = loadAndValidateContext({
       instance,
       workspace,
@@ -46,6 +56,7 @@ async function generateRepo(instance, workspace, branch, input, output, fetch = 
       inputFile,
       outputDir,
    });
+   printOutputDir(printOutput, outputDir);
 }
 
 function registerGenerateRepoCommand(program) {
@@ -56,6 +67,7 @@ function registerGenerateRepoCommand(program) {
       .option('--output <dir>', 'output directory (overrides config)');
 
    addFullContextOptions(cmd);
+   addPrintOutputFlag(cmd);
 
    cmd.option('--fetch', 'Specify this if you want to fetch the workspace schema from Xano').action(
       withErrorHandler(async (opts) => {
@@ -65,7 +77,8 @@ function registerGenerateRepoCommand(program) {
             opts.branch,
             opts.input,
             opts.output,
-            opts.fetch
+            opts.fetch,
+            opts.printOutput
          );
       })
    );

--- a/src/commands/run-lint.ts
+++ b/src/commands/run-lint.ts
@@ -1,9 +1,15 @@
 import { log } from '@clack/prompts';
 import { loadGlobalConfig } from '../config/loaders';
-import { getCurrentContextConfig, withErrorHandler, replacePlaceholders } from '../utils/index';
+import {
+   addPrintOutputFlag,
+   getCurrentContextConfig,
+   printOutputDir,
+   replacePlaceholders,
+   withErrorHandler,
+} from '../utils/index';
 import { runLintXano } from '../features/lint-xano/index';
 
-async function runLinter() {
+async function runLinter(printOutput: boolean = false) {
    const globalConfig = loadGlobalConfig();
    const context = globalConfig.currentContext;
 
@@ -43,19 +49,22 @@ async function runLinter() {
    );
 
    await runLintXano({ inputDir, ruleConfig, outputFile: outputPath });
+   printOutputDir(printOutput, outputDir);
 }
 
 function registerLintCommand(program) {
-   program
+   const cmd = program
       .command('lint')
       .description(
          'Lint backend logic, based on provided local file. Remote and dynamic sources are WIP...'
-      )
-      .action(
-         withErrorHandler(async () => {
-            await runLinter();
-         })
       );
+
+   addPrintOutputFlag(cmd);
+   cmd.action(
+      withErrorHandler(async (opts) => {
+         await runLinter(opts.printOutput);
+      })
+   );
 }
 
 export { registerLintCommand };

--- a/src/features/oas/generate/methods/update-spec-for-group.ts
+++ b/src/features/oas/generate/methods/update-spec-for-group.ts
@@ -1,12 +1,23 @@
 import { spinner } from '@clack/prompts';
-import { normalizeApiGroupName, replacePlaceholders, metaApiGet } from '../../../../utils/index';
+import {
+   normalizeApiGroupName,
+   replacePlaceholders,
+   metaApiGet,
+   printOutputDir,
+} from '../../../../utils/index';
 import { loadToken } from '../../../../config/loaders';
 import { doOasUpdate } from '../index';
 
 /**
  * Updates the OpenAPI spec for a single group.
  */
-async function updateSpecForGroup({ group, instanceConfig, workspaceConfig, branchConfig }) {
+async function updateSpecForGroup({
+   group,
+   instanceConfig,
+   workspaceConfig,
+   branchConfig,
+   printOutput,
+}) {
    const s = spinner();
    s.start(`Generating OpenAPI spec for group "${group.name}"`);
 
@@ -28,6 +39,7 @@ async function updateSpecForGroup({ group, instanceConfig, workspaceConfig, bran
    await doOasUpdate(openapiRaw, outputPath);
 
    s.stop(`OpenAPI spec generated for group "${group.name}" → ${outputPath}`);
+   printOutputDir(printOutput, outputPath);
 }
 
 export { updateSpecForGroup };

--- a/src/utils/commands/option-sets.ts
+++ b/src/utils/commands/option-sets.ts
@@ -45,3 +45,7 @@ export function addApiGroupOptions(cmd) {
          'Regenerate for all API groups in the workspace / branch of the current context.'
       );
 }
+
+export function addPrintOutputFlag(cmd) {
+   return cmd.option('--print-output-dir', 'Expose usable output path for further reuse.');
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -11,6 +11,7 @@ export * from './methods/fetch-and-extract-yaml';
 export * from './methods/get-current-context';
 export * from './methods/is-empty';
 export * from './methods/load-and-validate-context';
+export * from './methods/print-output-dir';
 export * from './methods/prepare-request';
 export * from './methods/replace-placeholders';
 export * from './methods/safe-version-control';

--- a/src/utils/methods/print-output-dir.ts
+++ b/src/utils/methods/print-output-dir.ts
@@ -1,0 +1,5 @@
+function printOutputDir(doLog: boolean = false, dir: string = ''): void {
+   if (doLog) console.log(`OUTPUT_DIR=${dir}`);
+}
+
+export { printOutputDir };


### PR DESCRIPTION
While the output paths are mostly dynamically generated at the same location based on the instance configuration, in a Github Action we have no idea about those paths. So there's a need to expose the generated files output dirs to the actions. 

This PR adds that support to the most important commands. 