### PR TITLE
refactor: rebrand, and removal of chalk dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,23 @@
 [//]: # 'ASCII art block for docs link'
 
 ```
-+----------------------------------------------------------------+
-|                                                                |
-|   ██╗  ██╗ █████╗ ███╗   ██╗ ██████╗      ██████╗██╗     ██╗   |
-|   ╚██╗██╔╝██╔══██╗████╗  ██║██╔═══██╗    ██╔════╝██║     ██║   |
-|    ╚███╔╝ ███████║██╔██╗ ██║██║   ██║    ██║     ██║     ██║   |
-|    ██╔██╗ ██╔══██║██║╚██╗██║██║   ██║    ██║     ██║     ██║   |
-|   ██╔╝ ██╗██║  ██║██║ ╚████║╚██████╔╝    ╚██████╗███████╗██║   |
-|   ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝ ╚═════╝      ╚═════╝╚══════╝╚═╝   |
-|                                                                |
-+----------------------------------------------------------------+
++-----------------------------------------------------------+
+|                                                           |
+|                                                           |
+|    ██████╗ █████╗ ██╗  ██╗   ██╗     ██████╗██╗     ██╗   |
+|   ██╔════╝██╔══██╗██║  ╚██╗ ██╔╝    ██╔════╝██║     ██║   |
+|   ██║     ███████║██║   ╚████╔╝     ██║     ██║     ██║   |
+|   ██║     ██╔══██║██║    ╚██╔╝      ██║     ██║     ██║   |
+|   ╚██████╗██║  ██║███████╗██║       ╚██████╗███████╗██║   |
+|    ╚═════╝╚═╝  ╚═╝╚══════╝╚═╝        ╚═════╝╚══════╝╚═╝   |
+|                                                           |
+|                                                           |
++-----------------------------------------------------------+
 ```
 
 [📚 **View Full CLI Documentation**](docs/README.md)
 
-# xano-community-cli
+# xano-tools
 
 **_(Work In Progress)_**
 
@@ -40,11 +42,11 @@
 
    -  Using pnpm (recommended):
       ```
-      pnpm exec xcc --help
+      pnpm exec caly --help
       ```
    -  Or using npx:
       ```
-      npx xcc --help
+      npx caly --help
       ```
 
 5. _(Optional)_ If you want the CLI globally available during development:
@@ -61,7 +63,7 @@
 
 You can use this CLI as a GitHub Action to automate your Xano workflows.
 
-Here is an example job that checks out your repository and uses the local composite action (`./dist/actions/master-action.yml`), which in turn securely downloads and runs the XCC CLI as npm package via the npx command.
+Here is an example job that checks out your repository and uses the local composite action (`./dist/actions/master-action.yml`), which in turn securely downloads and runs the Caly CLI as npm package via the npx command.
 
 ```yaml
 jobs:
@@ -105,7 +107,7 @@ I have been astonished by the shadcn/ui CLI and the core principles of code dist
 
 1. Scaffold the registry or build it manually by obeying the schemas (https://nextcurve.hu/schemas/registry/registry.json).
    ```
-   xcc registry-scaffold
+   caly registry-scaffold
    ```
 2. Serve your registry locally or host it on an object storage (or [advanced] recreate a Xano api that would deliver the required JSON objects on demand --> this could allow you to add auth as well)
 
@@ -115,9 +117,9 @@ I have been astonished by the shadcn/ui CLI and the core principles of code dist
 
    or use our script: `pnpm run serve-registry`
 
-3. Use the registry and it's content in `xcc`
+3. Use the registry and it's content in `caly`
    ```
-   xcc registry-add --components <coma separated component names> --registry <registry url>
+   caly registry-add --components <coma separated component names> --registry <registry url>
    ```
 
 > **Note:**

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,8 +4,8 @@ Supercharge your Xano workflow: automate backups, docs, testing, and version con
 
 ## Table of Contents
 
-- [xcc - the core commmand](xcc.md)
-#### Commands: 
+- [caly - the core commmand](caly.md)
+#### Commands:
 - [setup](commands/setup.md)
 - [switch-context](commands/switch-context.md)
 - [generate-oas](commands/generate-oas.md)
@@ -22,4 +22,4 @@ Supercharge your Xano workflow: automate backups, docs, testing, and version con
 - [test-via-oas](commands/test-via-oas.md)
 - [current-context](commands/current-context.md)
 
-Need further help? Visit https://github.com/MihalyToth20/xano-community-cli or reach out to Mihály Tóth on [State Change](https://statechange.ai/) or [Snappy Community](https://www.skool.com/snappy)
+Need further help? Visit https://github.com/calycode/xano-tools or reach out to Mihály Tóth on [State Change](https://statechange.ai/) or [Snappy Community](https://www.skool.com/snappy)

--- a/docs/xcc.md
+++ b/docs/xcc.md
@@ -1,5 +1,5 @@
 ```
-Usage: xcc <command> [options]
+Usage: caly <command> [options]
 
 
 +----------------------------------------------------------------+
@@ -77,7 +77,7 @@ Testing & Linting:
 
 Other:
   current-context     -h, --help
-    
 
-Need help? Visit https://github.com/MihalyToth20/xano-community-cli
+
+Need help? Visit https://github.com/calycode/xano-tools
 ```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-   "name": "@mihalytoth20/xano-community-cli-workspace",
+   "name": "@calycode/xano-tools-workspace",
    "version": "0.1.1",
    "type": "module",
    "description": "Supercharge your Xano workflow: automate backups, docs, testing, and version control—no AI guesswork, just reliable, transparent dev tools.",
@@ -12,8 +12,8 @@
    "scripts": {
       "build": "tsc --build",
       "build:packages": "pnpm -r --reporter=silent --workspace-concurrency=1 run build",
-      "xcc": "pnpm --filter @mihalytoth20/xano-community-cli run xcc",
-      "update-xcc-docs": "tsx scripts/generate-xcc-docs.ts",
+      "caly": "pnpm --filter @calycode/cli run caly",
+      "update-caly-docs": "tsx scripts/generate-caly-cli-docs.ts",
       "serve-registry": "npx serve registry --listen 3030",
       "clean": "pnpm -r run clean && trash dist tsconfig.tsbuildinfo",
       "prepublishOnly": "pnpm run build:packages"
@@ -25,7 +25,7 @@
    "keywords": [
       "Xano",
       "cli",
-      "xano-community-cli",
+      "xano-tools",
       "dev-tool"
    ],
    "author": "Mihály Tóth <hello@nextcurve.hu>",
@@ -44,11 +44,5 @@
       "trash-cli": "^6.0.0",
       "tsx": "^4.20.4",
       "typescript": "^5.9.2"
-   },
-   "dependencies": {
-      "@mihalytoth20/xano-community-cli": "link:../../../../Library/pnpm/global/5/node_modules/@mihalytoth20/xano-community-cli",
-      "@mihalytoth20/xcc-core": "link:packages/core",
-      "@mihalytoth20/xcc-types": "link:packages/types",
-      "@mihalytoth20/xcc-utils": "link:packages/utils"
    }
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
-# @mihalytoth20/xcc-cli
+# @calycode/cli
 
-Command-line interface for the Xano Community CLI (XCC) providing terminal access to Xano development workflows.
+Command-line interface for the Caly CLI providing terminal access to Xano development workflows.
 
 ## Overview
 
@@ -16,14 +16,14 @@ The CLI package provides:
 ### Global Installation
 
 ```bash
-npm install -g @mihalytoth20/xcc-cli
-xcc --help
+npm install -g @calycode/cli
+caly--help
 ```
 
 ### NPX Usage
 
 ```bash
-npx @mihalytoth20/xcc-cli --help
+npx @calycode/cli --help
 ```
 
 ## Commands
@@ -35,10 +35,10 @@ npx @mihalytoth20/xcc-cli --help
 Setup a new Xano instance configuration:
 
 ```bash
-xcc setup
+calysetup
 # Interactive prompts for instance name, URL, and API key
 
-xcc setup --name production --url https://x123.xano.io --api-key your-key
+calysetup --name production --url https://x123.xano.io --api-key your-key
 # Non-interactive setup
 ```
 
@@ -47,7 +47,7 @@ xcc setup --name production --url https://x123.xano.io --api-key your-key
 Display the current active context:
 
 ```bash
-xcc current-context
+calycurrent-context
 # Shows: stored json configuration
 ```
 
@@ -56,10 +56,10 @@ xcc current-context
 Switch to a different instance, workspace, or branch:
 
 ```bash
-xcc switch-context
+calyswitch-context
 # Interactive prompts
 
-xcc switch-context --instance staging --workspace main --branch develop
+calyswitch-context --instance staging --workspace main --branch develop
 # Non-interactive switch
 ```
 
@@ -70,13 +70,13 @@ xcc switch-context --instance staging --workspace main --branch develop
 Generate improved OpenAPI specifications:
 
 ```bash
-xcc generate-oas --group user-api
+calygenerate-oas --group user-api
 # Generate for specific API group
 
-xcc generate-oas --all
+calygenerate-oas --all
 # Generate for all API groups
 
-xcc generate-oas --instance production --workspace main --branch master --group api
+calygenerate-oas --instance production --workspace main --branch master --group api
 # Specify context
 ```
 
@@ -85,7 +85,7 @@ xcc generate-oas --instance production --workspace main --branch master --group 
 Serve OpenAPI specifications locally:
 
 ```bash
-xcc oas-serve
+calyoas-serve
 # Starts local server at http://localhost:5999
 ```
 
@@ -94,8 +94,8 @@ xcc oas-serve
 Generate client (and server) libraries from OpenAPI specs (see available [generators](https://openapi-generator.tech/docs/generators)):
 
 ```bash
-xcc generate-code --generator typescript-fetch
-xcc generate-code --generator python --output
+calygenerate-code --generator typescript-fetch
+calygenerate-code --generator python --output
 ```
 
 ### Backup & Restore
@@ -105,8 +105,8 @@ xcc generate-code --generator python --output
 Export workspace backup:
 
 ```bash
-xcc export-backup --output backup.tar.gz
-xcc export-backup --instance production --workspace main --branch master
+calyexport-backup --output backup.tar.gz
+calyexport-backup --instance production --workspace main --branch master
 ```
 
 #### `restore-backup`
@@ -114,7 +114,7 @@ xcc export-backup --instance production --workspace main --branch master
 Restore workspace from backup (cannot specify branch on restoration):
 
 ```bash
-xcc restore-backup --file backup.tar.gz --target-workspace staging
+calyrestore-backup --file backup.tar.gz --target-workspace staging
 ```
 
 ### Registry Operations
@@ -124,7 +124,7 @@ xcc restore-backup --file backup.tar.gz --target-workspace staging
 Create a new registry structure:
 
 ```bash
-xcc registry-scaffold --output ./my-registry
+calyregistry-scaffold --output ./my-registry
 ```
 
 #### `registry-add`
@@ -132,8 +132,8 @@ xcc registry-scaffold --output ./my-registry
 Install components to Xano from registry:
 
 ```bash
-xcc registry-add --registry ./local-registry --item user-auth
-xcc registry-add --registry https://registry.example.com --item payment-system
+calyregistry-add --registry ./local-registry --item user-auth
+calyregistry-add --registry https://registry.example.com --item payment-system
 ```
 
 #### `registry-serve`
@@ -141,7 +141,7 @@ xcc registry-add --registry https://registry.example.com --item payment-system
 Serve local registry:
 
 ```bash
-xcc registry-serve --registry ./my-registry --port 5000
+calyregistry-serve --registry ./my-registry --port 5000
 ```
 
 ### Development Tools
@@ -151,7 +151,7 @@ xcc registry-serve --registry ./my-registry --port 5000
 Generate browsable repository from workspace:
 
 ```bash
-xcc generate-repo
+calygenerate-repo
 ```
 
 #### `run-tests`
@@ -159,7 +159,7 @@ xcc generate-repo
 Run Xano workspace tests:
 
 ```bash
-xcc run-tests --group api --verbose
+calyrun-tests --group api --verbose
 ```
 
 #### `lint-xano`
@@ -167,14 +167,14 @@ xcc run-tests --group api --verbose
 Lint Xano workspace for best practices:
 
 ```bash
-xcc lint-xano --fix --output lint-report.json
+calylint-xano --fix --output lint-report.json
 ```
 
 ## Configuration
 
 ### Configuration Directory
 
-XCC stores configuration in `~/.xano-community-cli/`:
+calystores configuration in `~/.xano-tools/`:
 
 -  `config.json` - Global configuration
 -  `instances/` - Instance-specific configurations
@@ -203,31 +203,31 @@ Commands inherit context from:
 
 ```bash
 # Setup instance
-xcc setup --name production --url https://x123.xano.io --api-key your-key
+calysetup --name production --url https://x123.xano.io --api-key your-key
 
 # Generate OpenAPI specs
-xcc generate-oas --all
+calygenerate-oas --all
 
 # Generate TypeScript client
-xcc generate-code --generator typescript-fetch --output ./api-client
+calygenerate-code --generator typescript-fetch --output ./api-client
 
 # Serve documentation
-xcc oas-serve
+calyoas-serve
 ```
 
 ### Multi-Environment Setup
 
 ```bash
 # Setup multiple instances
-xcc setup --name production --url https://prod.xano.io --api-key prod-key
-xcc setup --name staging --url https://staging.xano.io --api-key staging-key
+calysetup --name production --url https://prod.xano.io --api-key prod-key
+calysetup --name staging --url https://staging.xano.io --api-key staging-key
 
 # Switch between environments
-xcc switch-context --instance staging
-xcc generate-oas --group api
+calyswitch-context --instance staging
+calygenerate-oas --group api
 
-xcc switch-context --instance production
-xcc export-backup --output prod-backup.tar.gz
+calyswitch-context --instance production
+calyexport-backup --output prod-backup.tar.gz
 ```
 
 ## Integration
@@ -238,8 +238,8 @@ xcc export-backup --output prod-backup.tar.gz
 # GitHub Actions example
 - name: Generate API Documentation
   run: |
-     npx @mihalytoth20/xcc-cli generate-oas --all
-     npx @mihalytoth20/xcc-cli generate-code --generator typescript-fetch --output ./api
+     npx @calycode/cli generate-oas --all
+     npx @calycode/cli generate-code --generator typescript-fetch --output ./api
   env:
      XANO_TOKEN_PRODUCTION: ${{ secrets.XANO_TOKEN }}
 ```

--- a/packages/cli/esbuild.config.ts
+++ b/packages/cli/esbuild.config.ts
@@ -10,7 +10,7 @@ const distDir = resolve(__dirname, 'dist');
 
 (async () => {
    try {
-      intro('Bundling XCC with esbuild');
+      intro('Bundling Caly with esbuild');
 
       // Copy github actions
       await cp(resolve(rootDir, 'src/actions'), resolve(distDir, 'actions'), {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "@mihalytoth20/xano-community-cli",
+    "name": "@calycode/cli",
     "version": "0.1.1",
-    "description": "Command-line interface for the Xano Community CLI providing terminal access to Xano workflows",
+    "description": "Command-line interface for Xano providing terminal access to Xano workflows",
     "keywords": [
         "xano",
         "cli",
@@ -13,7 +13,7 @@
         "developer-tools"
     ],
     "bin": {
-        "xcc": "dist/index.cjs"
+        "caly": "dist/index.cjs"
     },
     "main": "dist/index.cjs",
     "type": "module",
@@ -26,19 +26,18 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/MihalyToth20/xano-community-cli.git",
+        "url": "https://github.com/calycode/xano-tools.git",
         "directory": "packages/cli"
     },
     "bugs": {
-        "url": "https://github.com/MihalyToth20/xano-community-cli/issues"
+        "url": "https://github.com/calycode/xano-tools/issues"
     },
-    "homepage": "https://github.com/MihalyToth20/xano-community-cli/tree/main/packages/cli#readme",
+    "homepage": "https://github.com/calycode/xano-tools/tree/main/packages/cli#readme",
     "dependencies": {
         "@clack/prompts": "^0.11.0",
-        "@mihalytoth20/xcc-core": "workspace:*",
-        "@mihalytoth20/xcc-types": "workspace:*",
-        "@mihalytoth20/xcc-utils": "workspace:*",
-        "chalk": "^5.4.1",
+        "@calycode/caly-core": "workspace:*",
+        "@calycode/types": "workspace:*",
+        "@calycode/utils": "workspace:*",
         "commander": "^14.0.0",
         "js-yaml": "^4.1.0",
         "tar": "^7.4.3",
@@ -49,7 +48,7 @@
         "build:js": "tsx esbuild.config.ts",
         "build:chmod": "shx chmod +x dist/index.cjs",
         "build": "pnpm clean && pnpm build:js && pnpm build:chmod && pnpm link -g",
-        "xcc": "node dist/index.cjs"
+        "caly": "node dist/index.cjs"
     },
     "devDependencies": {
         "shx": "^0.4.0"

--- a/packages/cli/src/actions/dev-action.yml
+++ b/packages/cli/src/actions/dev-action.yml
@@ -1,13 +1,13 @@
 # This assumes the action is run from a repo that has the CLI as a dependency,
 # or is the CLI repo itself (not npm-installed).
 
-name: 'Xano Community CLI Dev Action'
-description: 'Sets up and runs a Xano Community CLI command in a GitHub workflow (dev/local version).'
-author: 'Xano Community'
+name: 'Caly CLI Dev Action'
+description: 'Sets up and runs a Caly CLI command in a GitHub workflow (dev/local version).'
+author: 'Mihály Tóth'
 
 inputs:
    run:
-      description: 'One or more xcc commands to run, each on a new line. e.g., "generate-oas --all"'
+      description: 'One or more caly commands to run, each on a new line. e.g., "generate-oas --all"'
       required: true
    instance-name:
       description: 'The name for the Xano instance (e.g., "prod").'
@@ -53,7 +53,7 @@ runs:
              if [ -z "$command_line" ]; then
                continue # Skip empty lines
              fi
-             echo "::group::Running: xcc $command_line"
+             echo "::group::Running: caly $command_line"
              OUTPUT=$(node src/index.js $command_line --instance="${{ inputs.instance-name }}" --print-output-dir)
              DIRS=$(echo "$OUTPUT" | grep 'OUTPUT_DIR=' | cut -d'=' -f2-)
              if [ -n "$DIRS" ]; then

--- a/packages/cli/src/actions/master-action.yml
+++ b/packages/cli/src/actions/master-action.yml
@@ -1,12 +1,12 @@
-# This action assumes that the XCC is already an NPM package and can be used
-# from a registry. Which is not the case yet.name: 'Xano Community CLI Action'
-name: 'Xano Community CLI Action'
-description: 'Sets up and runs a Xano Community CLI command in a GitHub workflow.'
-author: 'Xano Community'
+# This action assumes that the Caly CLI is already an NPM package and can be used
+# from a registry. Which is not the case yet.
+name: 'Caly CLI Action'
+description: 'Sets up and runs a Caly CLI command in a GitHub workflow.'
+author: 'Mihály Tóth'
 
 inputs:
    run:
-      description: 'One or more xcc commands to run, each on a new line. e.g., "generate-oas --all"'
+      description: 'One or more caly commands to run, each on a new line. e.g., "generate-oas --all"'
       required: true
    instance-name:
       description: 'The name for the Xano instance (e.g., "prod").'
@@ -18,7 +18,7 @@ inputs:
       description: 'The Xano Metadata API token. Should be stored as a GitHub secret.'
       required: true
    version:
-      description: 'The version of xano-community-cli to use from npm (e.g., 0.1.1, latest).'
+      description: 'The version of xano-tools to use from npm (e.g., 0.1.1, latest).'
       required: false
       default: 'latest'
 
@@ -39,7 +39,7 @@ runs:
            # This step uses npx to download and run the setup command.
            # For private packages, the consuming workflow must configure node-auth prior to this step.
            echo "::group::Configuring Xano CLI Instance"
-           npx --yes @mihalytoth20/xano-community-cli@${{ inputs.version }} setup \
+           npx --yes @calycode/xano-tools@${{ inputs.version }} setup \
              --name "${{ inputs.instance-name }}" \
              --url "${{ inputs.instance-url }}" \
              --token "${{ inputs.api-token }}" \
@@ -58,8 +58,8 @@ runs:
              if [ -z "$command_line" ]; then
                continue # Skip empty lines
              fi
-             echo "::group::Running: xcc $command_line"
-             OUTPUT=$(npx --yes @mihalytoth20/xano-community-cli@${{ inputs.version }} $command_line --instance=${{ inputs.instance-name }} --print-output-dir)
+             echo "::group::Running: caly $command_line"
+             OUTPUT=$(npx --yes @calycode/xano-tools@${{ inputs.version }} $command_line --instance=${{ inputs.instance-name }} --print-output-dir)
              DIRS=$(echo "$OUTPUT" | grep 'OUTPUT_DIR=' | cut -d'=' -f2-)
              if [ -n "$DIRS" ]; then
                OUTPUT_DIRS="${OUTPUT_DIRS}${DIRS}"$'\n'

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -2,7 +2,7 @@ import { mkdir } from 'fs/promises';
 import { writeFileSync, existsSync, mkdirSync } from 'fs';
 import { dirname, join } from 'path';
 import { log, outro, intro, spinner } from '@clack/prompts';
-import { metaApiGet, replacePlaceholders, sanitizeFileName } from '@mihalytoth20/xcc-utils';
+import { metaApiGet, replacePlaceholders, sanitizeFileName } from '@calycode/utils';
 import {
    withErrorHandler,
    addFullContextOptions,

--- a/packages/cli/src/commands/backups.ts
+++ b/packages/cli/src/commands/backups.ts
@@ -2,7 +2,7 @@ import path, { join } from 'path';
 import { readdirSync } from 'fs';
 import { openAsBlob } from 'node:fs';
 import { select, confirm, outro, } from '@clack/prompts';
-import { replacePlaceholders } from '@mihalytoth20/xcc-utils';
+import { replacePlaceholders } from '@calycode/utils';
 import {
    addFullContextOptions,
    addPartialContextOptions,

--- a/packages/cli/src/commands/generate-code.ts
+++ b/packages/cli/src/commands/generate-code.ts
@@ -1,5 +1,5 @@
 import { log, outro, intro, spinner } from '@clack/prompts';
-import { metaApiGet, normalizeApiGroupName, replacePlaceholders } from '@mihalytoth20/xcc-utils';
+import { metaApiGet, normalizeApiGroupName, replacePlaceholders } from '@calycode/utils';
 import {
    addApiGroupOptions,
    addFullContextOptions,

--- a/packages/cli/src/commands/generate-oas.ts
+++ b/packages/cli/src/commands/generate-oas.ts
@@ -3,7 +3,7 @@ import {
    replacePlaceholders,
    joinPath,
    dirname,
-} from '@mihalytoth20/xcc-utils';
+} from '@calycode/utils';
 import {
    addApiGroupOptions,
    addFullContextOptions,

--- a/packages/cli/src/commands/generate-repo.ts
+++ b/packages/cli/src/commands/generate-repo.ts
@@ -7,7 +7,7 @@ import {
    dirname,
    replacePlaceholders,
    fetchAndExtractYaml,
-} from '@mihalytoth20/xcc-utils';
+} from '@calycode/utils';
 import {
    addFullContextOptions,
    addPrintOutputFlag,

--- a/packages/cli/src/commands/generate-xanoscript-repo.ts
+++ b/packages/cli/src/commands/generate-xanoscript-repo.ts
@@ -1,7 +1,7 @@
 import { existsSync, readdirSync, lstatSync, rmdirSync, unlinkSync, mkdirSync } from 'fs';
-import { joinPath, dirname } from '@mihalytoth20/xcc-utils';
+import { joinPath, dirname } from '@calycode/utils';
 import { attachCliEventHandlers } from '../utils/event-listener';
-import { replacePlaceholders } from '@mihalytoth20/xcc-utils';
+import { replacePlaceholders } from '@calycode/utils';
 import { printOutputDir } from '../utils';
 import { addFullContextOptions, addPrintOutputFlag, withErrorHandler } from '../utils';
 

--- a/packages/cli/src/commands/run-lint.ts
+++ b/packages/cli/src/commands/run-lint.ts
@@ -1,5 +1,5 @@
 import { log } from '@clack/prompts';
-import { replacePlaceholders } from '@mihalytoth20/xcc-utils';
+import { replacePlaceholders } from '@calycode/utils';
 import { addPrintOutputFlag, printOutputDir, withErrorHandler } from '../utils/index';
 import { runLintXano } from '../features/lint-xano';
 

--- a/packages/cli/src/commands/run-tests.ts
+++ b/packages/cli/src/commands/run-tests.ts
@@ -7,7 +7,7 @@ import {
    normalizeApiGroupName,
    prepareRequest,
    replacePlaceholders,
-} from '@mihalytoth20/xcc-utils';
+} from '@calycode/utils';
 import {
    availableAsserts,
    addFullContextOptions,

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'child_process';
-import { normalizeApiGroupName, replacePlaceholders } from '@mihalytoth20/xcc-utils';
+import { normalizeApiGroupName, replacePlaceholders } from '@calycode/utils';
 import { addApiGroupOptions, addFullContextOptions, chooseApiGroupOrAll } from '../utils/index';
 
 // [ ] CLI

--- a/packages/cli/src/commands/setup-instance.ts
+++ b/packages/cli/src/commands/setup-instance.ts
@@ -1,5 +1,5 @@
 import { intro, text, password, confirm } from '@clack/prompts';
-import { sanitizeInstanceName } from '@mihalytoth20/xcc-utils';
+import { sanitizeInstanceName } from '@calycode/utils';
 import { ensureGitignore, withErrorHandler } from '../utils/index';
 
 async function setupInstanceWizard(core) {

--- a/packages/cli/src/features/lint-xano/XanoLinter.ts
+++ b/packages/cli/src/features/lint-xano/XanoLinter.ts
@@ -1,6 +1,6 @@
 // src/lint-xano/XanoLinter.js
 import { availableRules } from './rules/index';
-import { isNotEmpty } from '@mihalytoth20/xcc-utils';
+import { isNotEmpty } from '@calycode/utils';
 
 // ----- Linting rule functions -----
 async function lintObject(obj, errors, ruleConfig, parentKey = '', parentObj = obj) {
@@ -34,9 +34,9 @@ async function lintObject(obj, errors, ruleConfig, parentKey = '', parentObj = o
 
       const additionalRules = [
          {
-            condition: () => parentKey.includes('search.expression') && 
-                           parentKey.includes('statement.left') && 
-                           key === 'filters' && 
+            condition: () => parentKey.includes('search.expression') &&
+                           parentKey.includes('statement.left') &&
+                           key === 'filters' &&
                            Array.isArray(value) && value.length > 0,
             message: `Database query left operand should not have filters in "${obj.index ?? ''} ${obj.name} ${obj.as ?? ''}".`,
             rule: "DB queries: Don't put filters in left operand"

--- a/packages/cli/src/features/lint-xano/rules/index.ts
+++ b/packages/cli/src/features/lint-xano/rules/index.ts
@@ -1,5 +1,5 @@
 // src/lint-xano/rules/index.js
-import { isNotEmpty } from '@mihalytoth20/xcc-utils';
+import { isNotEmpty } from '@calycode/utils';
 
 const VALID_HEADERS = new Set(['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD']);
 

--- a/packages/cli/src/node-config-storage.ts
+++ b/packages/cli/src/node-config-storage.ts
@@ -1,11 +1,11 @@
 /**
- * Node.js filesystem-based implementation of ConfigStorage for XCC CLI.
- * Stores configuration files in the user's home directory under .xano-community-cli/
- * 
+ * Node.js filesystem-based implementation of ConfigStorage for  Caly CLI.
+ * Stores configuration files in the user's home directory under .xano-tools/
+ *
  * Directory structure:
- * - ~/.xano-community-cli/config.json (global configuration)
- * - ~/.xano-community-cli/instances/ (instance-specific configurations)
- * - ~/.xano-community-cli/tokens/ (API tokens with restricted permissions)
+ * - ~/.xano-tools/config.json (global configuration)
+ * - ~/.xano-tools/instances/ (instance-specific configurations)
+ * - ~/.xano-tools/tokens/ (API tokens with restricted permissions)
  */
 import fs from 'fs';
 import path from 'path';
@@ -13,29 +13,29 @@ import os from 'os';
 import { x } from 'tar';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { ConfigStorage } from '@mihalytoth20/xcc-types';
+import { ConfigStorage } from '@calycode/types';
 
-const baseDir = path.join(os.homedir(), '.xano-community-cli');
+const baseDir = path.join(os.homedir(), '.xano-tools');
 const configPath = path.join(baseDir, 'config.json');
 const instancesDir = path.join(baseDir, 'instances');
 const tokensDir = path.join(baseDir, 'tokens');
 
 /**
  * Node.js implementation of the ConfigStorage interface.
- * Provides file system operations and configuration management for the XCC CLI.
- * 
+ * Provides file system operations and configuration management for the Caly CLI.
+ *
  * @example
  * ```typescript
- * import { XCC } from '@mihalytoth20/xcc-core';
- * import { nodeConfigStorage } from '@mihalytoth20/xcc-cli';
- * 
+ * import { XCC } from '@calycode/caly-core';
+ * import { nodeConfigStorage } from '@calycode/cli';
+ *
  * const xcc = new XCC(nodeConfigStorage);
  * ```
  */
 export const nodeConfigStorage: ConfigStorage = {
    /**
     * Ensures that required configuration directories exist.
-    * Creates ~/.xano-community-cli/instances and ~/.xano-community-cli/tokens if they don't exist.
+    * Creates ~/.xano-tools/instances and ~/.xano-tools/tokens if they don't exist.
     */
    async ensureDirs() {
       [instancesDir, tokensDir].forEach((dir) => {
@@ -44,7 +44,7 @@ export const nodeConfigStorage: ConfigStorage = {
    },
 
    /**
-    * Loads the global XCC configuration from ~/.xano-community-cli/config.json.
+    * Loads the global XCC configuration from ~/.xano-tools/config.json.
     * Returns default configuration if file doesn't exist.
     * @returns Global configuration object with current context and instance list
     */
@@ -86,7 +86,7 @@ export const nodeConfigStorage: ConfigStorage = {
       const p = path.join(tokensDir, `${instance}.token`);
       if (!fs.existsSync(p)) {
          throw new Error(
-            `Token not found for instance: ${instance}. Please provide it via the ${envVarName} environment variable or run 'xcc setup'.`
+            `Token not found for instance: ${instance}. Please provide it via the ${envVarName} environment variable or run 'caly setup'.`
          );
       }
       return fs.readFileSync(p, 'utf-8').trim();

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import chalk from 'chalk';
+import { font } from './utils';
 import pkg from '../../../package.json' with {type: "json"};
 
 // Import commands:
@@ -15,7 +15,7 @@ import { registerTestViaOasCommand } from './commands/run-tests';
 import { registerRegistryAddCommand, registerRegistryScaffoldCommand } from './commands/registry';
 import { registerOasServeCommand, registerRegistryServeCommand } from './commands/serve';
 import { registerBuildXanoscriptRepoCommand } from './commands/generate-xanoscript-repo';
-import { XCC } from '@mihalytoth20/xcc-core';
+import { XCC } from '@calycode/caly-core';
 import { nodeConfigStorage } from './node-config-storage';
 
 const commandStartTimes = new WeakMap<Command, number>();
@@ -47,28 +47,30 @@ program.hook('postAction', (thisCommand, actionCommand) => {
 });
 
 program
-  .name('xcc')
+  .name('caly')
   .version(version, '-v, --version', 'output the version number')
   .usage('<command> [options]')
   .description(
-    chalk.cyan(`
-+----------------------------------------------------------------+
-|                                                                |
-|   ██╗  ██╗ █████╗ ███╗   ██╗ ██████╗      ██████╗██╗     ██╗   |
-|   ╚██╗██╔╝██╔══██╗████╗  ██║██╔═══██╗    ██╔════╝██║     ██║   |
-|    ╚███╔╝ ███████║██╔██╗ ██║██║   ██║    ██║     ██║     ██║   |
-|    ██╔██╗ ██╔══██║██║╚██╗██║██║   ██║    ██║     ██║     ██║   |
-|   ██╔╝ ██╗██║  ██║██║ ╚████║╚██████╔╝    ╚██████╗███████╗██║   |
-|   ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝ ╚═════╝      ╚═════╝╚══════╝╚═╝   |
-|                                                                |
-+----------------------------------------------------------------+
+    font.color.cyan(`
++-----------------------------------------------------------+
+|                                                           |
+|                                                           |
+|    ██████╗ █████╗ ██╗  ██╗   ██╗     ██████╗██╗     ██╗   |
+|   ██╔════╝██╔══██╗██║  ╚██╗ ██╔╝    ██╔════╝██║     ██║   |
+|   ██║     ███████║██║   ╚████╔╝     ██║     ██║     ██║   |
+|   ██║     ██╔══██║██║    ╚██╔╝      ██║     ██║     ██║   |
+|   ╚██████╗██║  ██║███████╗██║       ╚██████╗███████╗██║   |
+|    ╚═════╝╚═╝  ╚═╝╚══════╝╚═╝        ╚═════╝╚══════╝╚═╝   |
+|                                                           |
+|                                                           |
++-----------------------------------------------------------+
 `) +
     '\n\n' +
-    chalk.yellowBright('Supercharge your Xano workflow: ') +
-    chalk.white('automate ') + chalk.bold.cyan('backups') + chalk.white(', ') +
-    chalk.bold.cyan('docs') + chalk.white(', ') +
-    chalk.bold.cyan('testing') + chalk.white(', and ') +
-    chalk.bold.cyan('version control') + chalk.white(' — no AI guesswork, just reliable, transparent dev tools.') +
+    font.color.yellowBright('Supercharge your Xano workflow: ') +
+    font.color.white('automate ') + font.combo.boldCyan('backups') + font.color.white(', ') +
+    font.combo.boldCyan('docs') + font.color.white(', ') +
+    font.combo.boldCyan('testing') + font.color.white(', and ') +
+    font.combo.boldCyan('version control') + font.color.white(' — no AI guesswork, just reliable, transparent dev tools.') +
     '\n\n' +
     `Current version: ${version}`
   );
@@ -106,27 +108,27 @@ program.configureHelp({
 
     const groups = [
       {
-        title: chalk.bold.cyan('Core Commands:'),
+        title: font.combo.boldCyan('Core Commands:'),
         commands: ['setup', 'switch-context'],
       },
       {
-        title: chalk.bold.cyan('Code Generation:'),
+        title: font.combo.boldCyan('Code Generation:'),
         commands: ['generate-oas', 'oas-serve', 'generate-code', 'generate-repo', 'generate-xs-repo', 'generate-functions'],
       },
       {
-        title: chalk.bold.cyan('Registry:'),
+        title: font.combo.boldCyan('Registry:'),
         commands: ['registry-add', 'registry-scaffold', 'registry-serve'],
       },
       {
-        title: chalk.bold.cyan('Backup & Restore:'),
+        title: font.combo.boldCyan('Backup & Restore:'),
         commands: ['export-backup', 'restore-backup'],
       },
       {
-        title: chalk.bold.cyan('Testing & Linting:'),
+        title: font.combo.boldCyan('Testing & Linting:'),
         commands: ['lint', 'test-via-oas'],
       },
       {
-        title: chalk.bold.cyan('Other:'),
+        title: font.combo.boldCyan('Other:'),
         commands: ['current-context'],
       },
     ];
@@ -136,7 +138,7 @@ program.configureHelp({
 
     // Usage line
     let output = [
-      chalk.bold(`\nUsage: xcc <command> [options]\n`)
+      font.weight.bold(`\nUsage: caly <command> [options]\n`)
     ];
 
     // Banner and description
@@ -145,10 +147,10 @@ program.configureHelp({
     }
 
     // Options
-    output.push(chalk.bold('Options:'));
+    output.push(font.weight.bold('Options:'));
     output.push(
-      `  -v, --version   ${chalk.gray('output the version number')}\n` +
-      `  -h, --help      ${chalk.gray('display help for command')}\n`
+      `  -v, --version   ${font.color.gray('output the version number')}\n` +
+      `  -h, --help      ${font.color.gray('display help for command')}\n`
     );
 
     // Command Groups
@@ -158,10 +160,10 @@ program.configureHelp({
         const c = cmdMap[cname];
         if (c) {
           // Only show -h, --help in main help for brevity
-          const opts = '  ' + chalk.gray('-h, --help');
+          const opts = '  ' + font.color.gray('-h, --help');
           // Align command names
           output.push(
-            `  ${chalk.bold(pad(c.name(), longestName))}${opts}\n    ${c.description()}\n`
+            `  ${font.weight.bold(pad(c.name(), longestName))}${opts}\n    ${c.description()}\n`
           );
         }
       }
@@ -169,7 +171,7 @@ program.configureHelp({
 
     // Footer/help link
     output.push(
-      chalk.gray('Need help? Visit https://github.com/MihalyToth20/xano-community-cli\n')
+      font.color.gray('Need help? Visit https://github.com/calycode/xano-tools\n')
     );
 
     return output.join('\n');

--- a/packages/cli/src/utils/event-listener.ts
+++ b/packages/cli/src/utils/event-listener.ts
@@ -1,6 +1,6 @@
 import { intro, outro, log, spinner } from '@clack/prompts';
 import { printOutputDir } from './methods/print-output-dir';
-import { EventName } from '@mihalytoth20/xcc-types';
+import { EventName } from '@calycode/types';
 
 export type CoreEventName = 'start' | 'end' | 'progress' | 'error' | 'info';
 export type HandlerFn = (data: any, context?: any) => void;

--- a/packages/cli/src/utils/feature-focused/registry/general.ts
+++ b/packages/cli/src/utils/feature-focused/registry/general.ts
@@ -1,4 +1,4 @@
-import { metaApiGet, metaApiPost } from '@mihalytoth20/xcc-utils';
+import { metaApiGet, metaApiPost } from '@calycode/utils';
 import { getRegistryIndex } from '../../index';
 
 // [ ] CLI, whole file

--- a/packages/cli/src/utils/feature-focused/registry/scaffold.ts
+++ b/packages/cli/src/utils/feature-focused/registry/scaffold.ts
@@ -58,14 +58,14 @@ async function scaffoldRegistry(
          {
             path: `${componentsRoot}/functions/${functionFileName}`,
             type: 'registry:function',
-            target: `/xcc/${functionName}`,
+            target: `/caly/${functionName}`,
          },
       ],
    };
 
    const sampleIndex = {
       $schema: 'https://nextcurve.hu/schemas/registry/registry.json',
-      name: 'xano-community-registry',
+      name: 'caly-xano-registry',
       homepage: 'https://nextcurve.hu',
       items: [sampleRegistryItem],
    };

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -7,3 +7,4 @@ export * from './methods/choose-api-group';
 export * from './methods/print-output-dir';
 export * from './methods/safe-version-control';
 export * from './methods/with-error-handler';
+export * from './methods/font';

--- a/packages/cli/src/utils/methods/choose-api-group.ts
+++ b/packages/cli/src/utils/methods/choose-api-group.ts
@@ -1,6 +1,6 @@
 import { select } from '@clack/prompts';
-import { metaApiGet } from '@mihalytoth20/xcc-utils';
-import { ApiGroup, ChooseApiGroupOrAllOptions } from '@mihalytoth20/xcc-types';
+import { metaApiGet } from '@calycode/utils';
+import { ApiGroup, ChooseApiGroupOrAllOptions } from '@calycode/types';
 
 // [ ] CLI
 export async function chooseApiGroupOrAll({

--- a/packages/cli/src/utils/methods/font.ts
+++ b/packages/cli/src/utils/methods/font.ts
@@ -1,0 +1,32 @@
+function wrap(open: number, close: number) {
+   return (str: string) => `\x1b[${open}m${str}\x1b[${close}m`;
+}
+
+// Colors
+const cyan = wrap(36, 39);
+const yellowBright = wrap(93, 39);
+const white = wrap(37, 39);
+const gray = wrap(90, 39);
+
+// Weight
+const bold = wrap(1, 22);
+
+// Combined color + weight variants
+const boldCyan = (str: string) => bold(cyan(str));
+
+const font = {
+   color: {
+      cyan,
+      yellowBright,
+      white,
+      gray,
+   },
+   weight: {
+      bold,
+   },
+   combo: {
+      boldCyan,
+   },
+};
+
+export { font };

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
-# @mihalytoth20/xcc-core
+# @calycode/caly-core
 
-Core functionality for the Xano Community CLI (XCC) providing programmatic access to Xano development workflows.
+Core functionality for the Caly CLI providing programmatic access to Xano development workflows.
 
 ## Overview
 
@@ -37,9 +37,9 @@ The core package provides the main `XCC` class that orchestrates all Xano operat
 ### Basic Setup
 
 ```typescript
-import { XCC } from '@mihalytoth20/xcc-core';
+import { XCC } from '@calycode/caly-core';
 // Implement your own storage interface based on the platform you're using
-import { nodeConfigStorage } from '@mihalytoth20/xcc-cli';
+import { nodeConfigStorage } from '@calycode/cli';
 
 const xcc = new XCC(nodeConfigStorage);
 
@@ -138,13 +138,13 @@ All methods include comprehensive error handling with descriptive error messages
 ## Installation
 
 ```bash
-npm install @mihalytoth20/xcc-core
+npm install @calycode/caly-core
 ```
 
 ## Dependencies
 
-- `@mihalytoth20/xcc-types` - TypeScript type definitions
-- `@mihalytoth20/xcc-utils` - Utility functions
+- `@calycode/types` - TypeScript type definitions
+- `@calycode/utils` - Utility functions
 
 ## License
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "@mihalytoth20/xcc-core",
+    "name": "@calycode/caly-core",
     "version": "0.1.0",
-    "description": "Core functionality for the Xano Community CLI providing programmatic access to Xano workflows",
+    "description": "Core functionality for the Caly Xano tooling providing programmatic access to Xano workflows",
     "keywords": [
         "xano",
         "cli",
@@ -24,16 +24,16 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/MihalyToth20/xano-community-cli.git",
+        "url": "https://github.com/calycode/xano-tools.git",
         "directory": "packages/core"
     },
     "bugs": {
-        "url": "https://github.com/MihalyToth20/xano-community-cli/issues"
+        "url": "https://github.com/calycode/xano-tools/issues"
     },
-    "homepage": "https://github.com/MihalyToth20/xano-community-cli/tree/main/packages/core#readme",
+    "homepage": "https://github.com/calycode/xano-tools/tree/main/packages/core#readme",
     "dependencies": {
-        "@mihalytoth20/xcc-types": "workspace:*",
-        "@mihalytoth20/xcc-utils": "workspace:*"
+        "@calycode/types": "workspace:*",
+        "@calycode/utils": "workspace:*"
     },
     "scripts": {
         "clean": "trash dist tsconfig.tsbuildinfo",

--- a/packages/core/src/features/oas/generate/methods/do-oas-update.ts
+++ b/packages/core/src/features/oas/generate/methods/do-oas-update.ts
@@ -1,4 +1,4 @@
-import { joinPath } from '@mihalytoth20/xcc-utils';
+import { joinPath } from '@calycode/utils';
 import { patchOasSpec } from './index';
 
 interface GeneratedItem {

--- a/packages/core/src/features/oas/generate/methods/generate-table-schemas.ts
+++ b/packages/core/src/features/oas/generate/methods/generate-table-schemas.ts
@@ -1,5 +1,5 @@
 import { convertXanoSchemaToJsonSchema } from './convert-xano-schemas';
-import { metaApiGet } from '@mihalytoth20/xcc-utils';
+import { metaApiGet } from '@calycode/utils';
 
 // [ ] CORE
 async function generateTableSchemas({ instanceConfig, workspaceConfig, storage }) {

--- a/packages/core/src/features/oas/generate/methods/update-spec-for-group.ts
+++ b/packages/core/src/features/oas/generate/methods/update-spec-for-group.ts
@@ -1,4 +1,4 @@
-import { metaApiGet } from '@mihalytoth20/xcc-utils';
+import { metaApiGet } from '@calycode/utils';
 import { doOasUpdate } from '../index';
 
 interface GeneratedItem {

--- a/packages/core/src/features/process-xano/core/generate-structure-diagrams.ts
+++ b/packages/core/src/features/process-xano/core/generate-structure-diagrams.ts
@@ -1,4 +1,4 @@
-import { joinPath } from '@mihalytoth20/xcc-utils';
+import { joinPath } from '@calycode/utils';
 
 type Query = Partial<{ name: string; verb: string }>;
 type AppQueries = Record<string, Query[]>;

--- a/packages/core/src/features/process-xano/core/processItem.ts
+++ b/packages/core/src/features/process-xano/core/processItem.ts
@@ -1,6 +1,6 @@
 import { generateQueryLogicDescription } from './generateRunReadme';
 import { convertXanoDBDescription } from '../adapters/dbmlGenerator';
-import { sanitizeFileName, joinPath } from '@mihalytoth20/xcc-utils';
+import { sanitizeFileName, joinPath } from '@calycode/utils';
 
 function getItemDir({ key, item, dirPath, appMapping }) {
    let baseDir;

--- a/packages/core/src/features/process-xano/index.ts
+++ b/packages/core/src/features/process-xano/index.ts
@@ -1,5 +1,5 @@
 import { processItem } from './core/processItem';
-import { sanitizeFileName } from '@mihalytoth20/xcc-utils';
+import { sanitizeFileName } from '@calycode/utils';
 import { generateStructureDiagrams } from './core/generate-structure-diagrams';
 import type { XCC } from '../../';
 

--- a/packages/core/src/implementations/backups.ts
+++ b/packages/core/src/implementations/backups.ts
@@ -1,4 +1,4 @@
-import { replacePlaceholders, metaApiRequestBlob, joinPath } from '@mihalytoth20/xcc-utils';
+import { replacePlaceholders, metaApiRequestBlob, joinPath } from '@calycode/utils';
 
 /**
  * Exports a backup and emits events for CLI/UI.

--- a/packages/core/src/implementations/build-xanoscript-repo.ts
+++ b/packages/core/src/implementations/build-xanoscript-repo.ts
@@ -1,6 +1,6 @@
-import { metaApiGet, sanitizeFileName } from '@mihalytoth20/xcc-utils';
+import { metaApiGet, sanitizeFileName } from '@calycode/utils';
 import type { XCC } from '..';
-import type { CoreContext } from '@mihalytoth20/xcc-types';
+import type { CoreContext } from '@calycode/types';
 
 async function fetchAndProcessEntities({
    baseUrl,

--- a/packages/core/src/implementations/generate-oas.ts
+++ b/packages/core/src/implementations/generate-oas.ts
@@ -1,6 +1,6 @@
 import { updateSpecForGroup } from '../features/oas/generate/methods/update-spec-for-group';
 import type { XCC } from '..';
-import { ApiGroup } from '@mihalytoth20/xcc-types';
+import { ApiGroup } from '@calycode/types';
 
 async function updateOpenapiSpecImplementation(
    storage: XCC["storage"],

--- a/packages/core/src/implementations/get-current-context.ts
+++ b/packages/core/src/implementations/get-current-context.ts
@@ -6,7 +6,7 @@ import {
    ApiGroupConfig,
    CurrentContextConfig,
    ConfigStorage,
-} from '@mihalytoth20/xcc-types';
+} from '@calycode/types';
 
 // [ ] CORE, needs fs
 /**

--- a/packages/core/src/implementations/load-and-validate-context.ts
+++ b/packages/core/src/implementations/load-and-validate-context.ts
@@ -1,5 +1,5 @@
 // core/config.ts
-import { ConfigStorage, InstanceConfig, WorkspaceConfig, BranchConfig, Context } from '@mihalytoth20/xcc-types';
+import { ConfigStorage, InstanceConfig, WorkspaceConfig, BranchConfig, Context } from '@calycode/types';
 import { getCurrentContextConfigImplementation } from './get-current-context';
 
 function assignDefined<T>(base: T, overrides: Partial<T>): T {

--- a/packages/core/src/implementations/setup.ts
+++ b/packages/core/src/implementations/setup.ts
@@ -1,5 +1,5 @@
-import { ConfigStorage } from '@mihalytoth20/xcc-types';
-import { sanitizeInstanceName, fetchWorkspacesAndBranches } from '@mihalytoth20/xcc-utils';
+import { ConfigStorage } from '@calycode/types';
+import { sanitizeInstanceName, fetchWorkspacesAndBranches } from '@calycode/utils';
 
 // DEFAULT SETTINGS:
 const DEFAULT_LINT_RULES: Record<string, 'error' | 'warn' | 'off'> = {

--- a/packages/core/src/implementations/switch-context.ts
+++ b/packages/core/src/implementations/switch-context.ts
@@ -1,4 +1,4 @@
-import { ConfigStorage, CoreContext } from '@mihalytoth20/xcc-types';
+import { ConfigStorage, CoreContext } from '@calycode/types';
 
 export async function switchContextImplementation(
    storage: ConfigStorage,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,7 @@ import {
    EventMap,
    InstanceConfig,
    WorkspaceConfig,
-} from '@mihalytoth20/xcc-types';
+} from '@calycode/types';
 import { TypedEmitter } from './utils/event-handling/event-emitter';
 import { doOasUpdate } from './features/oas/generate';
 import { exportBackupImplementation, restoreBackupImplementation } from './implementations/backups';
@@ -20,13 +20,13 @@ import { updateOpenapiSpecImplementation } from './implementations/generate-oas'
 import { buildXanoscriptRepoImplementation } from './implementations/build-xanoscript-repo';
 
 /**
- * Main XCC (Xano Community CLI) class that provides core functionality for Xano development workflows.
+ * Main XCC class that provides core functionality for Xano development workflows.
  * Extends TypedEmitter to provide event-driven architecture for CLI operations.
  *
  * @example
  * ```typescript
- * import { XCC } from '@mihalytoth20/xcc-core';
- * import { nodeConfigStorage } from '@mihalytoth20/xcc-cli';
+ * import { XCC } from '@calycode/caly-core';
+ * import { nodeConfigStorage } from '@calycode/cli';
  *
  * const xcc = new XCC(nodeConfigStorage);
  *

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,6 +1,6 @@
-# @mihalytoth20/xcc-types
+# @calycode/types
 
-TypeScript type definitions and interfaces for the Xano Community CLI (XCC) ecosystem.
+TypeScript type definitions and interfaces for the Caly Xano tooling ecosystem.
 
 ## Overview
 
@@ -45,7 +45,7 @@ import {
   WorkspaceConfig,
   Context,
   ConfigStorage
-} from '@mihalytoth20/xcc-types';
+} from '@calycode/types';
 
 // Define a context for operations
 const context: Context = {
@@ -68,7 +68,7 @@ class MyStorage implements ConfigStorage {
 This package is typically installed as a dependency of other XCC packages and doesn't need to be installed directly.
 
 ```bash
-npm install @mihalytoth20/xcc-types
+npm install @calycode/types
 ```
 
 ## License

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "@mihalytoth20/xcc-types",
+    "name": "@calycode/types",
     "version": "0.1.0",
-    "description": "TypeScript type definitions for the Xano Community CLI ecosystem",
+    "description": "TypeScript type definitions for the Caly Xano tooling ecosystem",
     "keywords": [
         "xano",
         "cli",
@@ -22,13 +22,13 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/MihalyToth20/xano-community-cli.git",
+        "url": "https://github.com/calycode/xano-tools.git",
         "directory": "packages/types"
     },
     "bugs": {
-        "url": "https://github.com/MihalyToth20/xano-community-cli/issues"
+        "url": "https://github.com/calycode/xano-tools/issues"
     },
-    "homepage": "https://github.com/MihalyToth20/xano-community-cli/tree/main/#readme",
+    "homepage": "https://github.com/calycode/xano-tools/tree/main/#readme",
     "scripts": {
         "clean": "trash dist tsconfig.tsbuildinfo",
         "build:types": "tsc",

--- a/packages/types/src/storage/index.ts
+++ b/packages/types/src/storage/index.ts
@@ -6,8 +6,8 @@ import { InstanceConfig, CoreContext } from '..';
  *
  * @example
  * ```typescript
- * // Node.js implementation (see the xcc-cli)
- * import { nodeConfigStorage } from '@mihalytoth20/xcc-cli';
+ * // Node.js implementation (see the cli)
+ * import { nodeConfigStorage } from '@calycode/cli';
  * const xcc = new XCC(nodeConfigStorage);
  *
  * // Custom implementation

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,6 +1,6 @@
-# @mihalytoth20/xcc-utils
+# @calycode/utils
 
-Utility functions and helpers for the Xano Community CLI (XCC) ecosystem.
+Utility functions and helpers for the Caly Xano tools ecosystem.
 
 ## Overview
 
@@ -35,7 +35,7 @@ This package provides core utility functions for:
 ### API Communication
 
 ```typescript
-import { metaApiGet, metaApiPost } from '@mihalytoth20/xcc-utils';
+import { metaApiGet, metaApiPost } from '@calycode/utils';
 
 // Get workspace information
 const workspace = await metaApiGet({
@@ -71,7 +71,7 @@ const newFunction = await metaApiPost({
 ### Workspace Discovery
 
 ```typescript
-import { fetchWorkspacesAndBranches } from '@mihalytoth20/xcc-utils';
+import { fetchWorkspacesAndBranches } from '@calycode/utils';
 
 const { workspaces, branches } = await fetchWorkspacesAndBranches(
   'https://x123.xano.io',
@@ -85,7 +85,7 @@ console.log('Branches for main workspace:', branches['main']);
 ### Template Processing
 
 ```typescript
-import { replacePlaceholders } from '@mihalytoth20/xcc-utils';
+import { replacePlaceholders } from '@calycode/utils';
 
 const template = {
   url: 'https://{instance}.xano.io/api/{version}',
@@ -103,7 +103,7 @@ const result = replacePlaceholders(template, {
 ### File Name Sanitization
 
 ```typescript
-import { sanitizeFileName } from '@mihalytoth20/xcc-utils';
+import { sanitizeFileName } from '@calycode/utils';
 
 const safeName = sanitizeFileName('My API Group!');
 // Returns: 'my_api_group_'
@@ -112,12 +112,12 @@ const safeName = sanitizeFileName('My API Group!');
 ## Installation
 
 ```bash
-npm install @mihalytoth20/xcc-utils
+npm install @calycode/utils
 ```
 
 ## Dependencies
 
-- `@mihalytoth20/xcc-types` - TypeScript type definitions
+- `@calycode/types` - TypeScript type definitions
 
 ## License
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "@mihalytoth20/xcc-utils",
+    "name": "@calycode/utils",
     "version": "0.1.0",
-    "description": "Utility functions and helpers for the Xano Community CLI ecosystem",
+    "description": "Utility functions and helpers for the Caly Xano tooling ecosystem",
     "keywords": [
         "xano",
         "cli",
@@ -23,15 +23,15 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/MihalyToth20/xano-community-cli.git",
+        "url": "https://github.com/calycode/xano-tools.git",
         "directory": "packages/utils"
     },
     "bugs": {
-        "url": "https://github.com/MihalyToth20/xano-community-cli/issues"
+        "url": "https://github.com/calycode/xano-tools/issues"
     },
-    "homepage": "https://github.com/MihalyToth20/xano-community-cli/tree/main/packages/utils#readme",
+    "homepage": "https://github.com/calycode/xano-tools/tree/main/packages/utils#readme",
     "dependencies": {
-        "@mihalytoth20/xcc-types": "workspace:*"
+        "@calycode/types": "workspace:*"
     },
     "scripts": {
         "clean": "trash dist tsconfig.tsbuildinfo",

--- a/packages/utils/src/methods/api-helper.ts
+++ b/packages/utils/src/methods/api-helper.ts
@@ -5,7 +5,7 @@ import {
    QueryParams,
    Headers,
    HTTPMethod,
-} from '@mihalytoth20/xcc-types';
+} from '@calycode/types';
 
 /**
  * Internal helper for building Xano Metadata API URLs with path parameters and query strings.
@@ -64,7 +64,7 @@ function buildHeaders(token: string, headers: Headers = {}, body: unknown = null
 /**
  * Makes authenticated HTTP requests to the Xano Metadata API.
  * Handles JSON parsing, error handling, and authentication automatically.
- * 
+ *
  * @param options - Configuration options for the API request
  * @param options.baseUrl - The base URL of the Xano instance
  * @param options.token - Bearer token for authentication
@@ -77,7 +77,7 @@ function buildHeaders(token: string, headers: Headers = {}, body: unknown = null
  * @param options.allowError - If true, won't throw on non-2xx responses
  * @returns Promise resolving to the parsed JSON response or text if JSON parsing fails
  * @throws {Error} When API request fails and allowError is false
- * 
+ *
  * @example
  * ```typescript
  * // Get workspace information
@@ -88,7 +88,7 @@ function buildHeaders(token: string, headers: Headers = {}, body: unknown = null
  *   path: '/workspace/{id}',
  *   pathParams: { id: '123' }
  * });
- * 
+ *
  * // Create a new function
  * const newFunction = await metaApiRequest({
  *   baseUrl: 'https://x123.xano.io',
@@ -137,7 +137,7 @@ async function metaApiRequest({
 /**
  * Makes authenticated HTTP requests to the Xano Metadata API for binary data.
  * Similar to metaApiRequest but returns raw binary data as Uint8Array.
- * 
+ *
  * @param options - Configuration options for the API request
  * @param options.baseUrl - The base URL of the Xano instance
  * @param options.token - Bearer token for authentication
@@ -149,7 +149,7 @@ async function metaApiRequest({
  * @param options.headers - Additional HTTP headers
  * @returns Promise resolving to binary data as Uint8Array
  * @throws {Error} When API request fails (always throws on non-2xx responses)
- * 
+ *
  * @example
  * ```typescript
  * // Download workspace backup
@@ -160,7 +160,7 @@ async function metaApiRequest({
  *   path: '/workspace/{id}/backup',
  *   pathParams: { id: '123' }
  * });
- * 
+ *
  * // Save to file
  * await fs.writeFile('backup.tar.gz', backupData);
  * ```
@@ -205,7 +205,7 @@ function makeMetaApiMethod<M extends HTTPMethod>(method: M) {
  * Convenience function for making GET requests to the Xano Metadata API.
  * @param options - API request options (method is automatically set to 'GET')
  * @returns Promise resolving to the API response
- * 
+ *
  * @example
  * ```typescript
  * const workspaces = await metaApiGet({
@@ -221,7 +221,7 @@ export const metaApiGet = makeMetaApiMethod('GET');
  * Convenience function for making POST requests to the Xano Metadata API.
  * @param options - API request options (method is automatically set to 'POST')
  * @returns Promise resolving to the API response
- * 
+ *
  * @example
  * ```typescript
  * const newWorkspace = await metaApiPost({

--- a/packages/utils/src/methods/fetch-and-extract-yaml.ts
+++ b/packages/utils/src/methods/fetch-and-extract-yaml.ts
@@ -1,5 +1,5 @@
 import { metaApiRequestBlob } from './api-helper';
-import { FetchAndExtractYamlArgs } from '@mihalytoth20/xcc-types';
+import { FetchAndExtractYamlArgs } from '@calycode/types';
 import { joinPath, dirname } from './path';
 
 // [ ] CORE

--- a/packages/utils/src/methods/is-empty.ts
+++ b/packages/utils/src/methods/is-empty.ts
@@ -1,13 +1,13 @@
 // Minimal schema type (customize as needed)
-import { TableSchemaItem } from '@mihalytoth20/xcc-types';
+import { TableSchemaItem } from '@calycode/types';
 
 /**
  * Checks if a schema object is empty or contains no meaningful type information.
  * Uses native JavaScript methods for efficient object inspection.
- * 
+ *
  * @param schema - The schema object to check
  * @returns True if the schema is empty or meaningless, false otherwise
- * 
+ *
  * @example
  * ```typescript
  * const emptySchema = isEmptySchema({}); // true
@@ -25,7 +25,7 @@ export function isEmptySchema(schema: unknown): boolean {
    if (typeof schema === 'object') {
       const obj = schema as TableSchemaItem;
       const keys = Object.keys(obj).filter((k) => !['type', 'description'].includes(k));
-      
+
       if (keys.length === 0) return true;
 
       if ('properties' in obj && obj.properties && Object.keys(obj.properties).length === 0) {

--- a/packages/utils/src/methods/prepare-request.ts
+++ b/packages/utils/src/methods/prepare-request.ts
@@ -1,5 +1,5 @@
 // --- Types ---
-import { Schema, PrepareRequestArgs, PreparedRequest } from '@mihalytoth20/xcc-types';
+import { Schema, PrepareRequestArgs, PreparedRequest } from '@calycode/types';
 
 /**
  * Prepares an HTTP request from OpenAPI specification parameters.

--- a/packages/utils/src/methods/sanitize.ts
+++ b/packages/utils/src/methods/sanitize.ts
@@ -1,5 +1,5 @@
 // src/utils/sanitize.ts
-import { SanitizeOptions } from '@mihalytoth20/xcc-types';
+import { SanitizeOptions } from '@calycode/types';
 
 const defaultOptions: Required<Omit<SanitizeOptions, 'allowedCharsRegex'>> & {
    allowedCharsRegex: RegExp;

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,8 @@
 packages:
-  - packages/*
+   - packages/*
 
 overrides:
-  '@mihalytoth20/xano-community-cli': link:../../../../Library/pnpm/global/5/node_modules/@mihalytoth20/xano-community-cli
-  '@mihalytoth20/xcc-core': link:packages/core
-  '@mihalytoth20/xcc-types': link:packages/types
-  '@mihalytoth20/xcc-utils': link:packages/utils
+   '@calycode/cli': link:../../../../Library/pnpm/global/5/node_modules/@calycode/cli
+   '@calycode/caly-core': link:packages/core
+   '@calycode/types': link:packages/types
+   '@calycode/utils': link:packages/utils

--- a/scripts/generate-caly-cli-docs.ts
+++ b/scripts/generate-caly-cli-docs.ts
@@ -13,7 +13,7 @@ function writeDocForCommand(cmd, dir = 'docs/commands') {
 }
 
 async function generateCliDocs() {
-   console.log('Generating XCC CLI Docs');
+   console.log('Generating Caly Xano CLI Docs');
 
    // 1. Clean docs directory
    rmSync('docs', { recursive: true, force: true });
@@ -31,7 +31,7 @@ async function generateCliDocs() {
 
    // 4. Generate a Table of Contents
    const tocLines = [
-      '# XCC CLI Command Reference',
+      '# Caly Xano CLI Command Reference',
       '',
       'Supercharge your Xano workflow: automate backups, docs, testing, and version control—no AI guesswork, just reliable, transparent dev tools.',
       '',
@@ -41,7 +41,7 @@ async function generateCliDocs() {
       '#### Commands: ',
       ...commandNames.map((name) => `- [${name}](commands/${name}.md)`),
       '',
-      'Need further help? Visit https://github.com/MihalyToth20/xano-community-cli or reach out to Mihály Tóth on [State Change](https://statechange.ai/) or [Snappy Community](https://www.skool.com/snappy)',
+      'Need further help? Visit https://github.com/calycode/xano-tools or reach out to Mihály Tóth on [State Change](https://statechange.ai/) or [Snappy Community](https://www.skool.com/snappy)',
       '',
    ];
    writeFileSync('docs/README.md', tocLines.join('\n'));


### PR DESCRIPTION
Just moving away from the 'Xano Community' naming. The project in its essence doesn't change, but being so strictly tied to Xano in branding terms is something I would like to avoid. 