### PR TITLE
feat: backup command fixes

### DIFF
--- a/.changeset/bright-teams-decide.md
+++ b/.changeset/bright-teams-decide.md
@@ -1,0 +1,8 @@
+---
+"@calycode/types": minor
+"@calycode/utils": minor
+"@calycode/core": minor
+"@calycode/cli": minor
+---
+
+feat: fixing and wrapping up backup exporting command

--- a/packages/cli/src/node-config-storage.ts
+++ b/packages/cli/src/node-config-storage.ts
@@ -237,21 +237,25 @@ export const nodeConfigStorage: ConfigStorage = {
    async writeFile(filePath, data) {
       await fs.promises.writeFile(filePath, data);
    },
-   async streamToFile(
-      destinationPath: string,
-      source: ReadableStream | NodeJS.ReadableStream
-   ): Promise<void> {
-      const dest = fs.createWriteStream(destinationPath, { mode: 0o600 });
+
+   async streamToFile({
+      path,
+      stream,
+   }: {
+      path: string;
+      stream: ReadableStream | NodeJS.ReadableStream;
+   }): Promise<void> {
+      const dest = fs.createWriteStream(path, { mode: 0o600 });
       let nodeStream: NodeJS.ReadableStream;
 
       // Convert if necessary
-      if (typeof (source as any).pipe === 'function') {
+      if (typeof (stream as any).pipe === 'function') {
          // already a NodeJS stream
-         nodeStream = source as NodeJS.ReadableStream;
+         nodeStream = stream as NodeJS.ReadableStream;
       } else {
          // WHATWG stream (from fetch in Node 18+)
          // Can only use fromWeb if available in the environment
-         nodeStream = Readable.fromWeb(source as any);
+         nodeStream = Readable.fromWeb(stream as any);
       }
 
       await new Promise<void>((resolve, reject) => {
@@ -261,9 +265,11 @@ export const nodeConfigStorage: ConfigStorage = {
          nodeStream.on('error', (err) => reject(err));
       });
    },
+
    async readFile(filePath) {
       return await fs.promises.readFile(filePath); // returns Buffer
    },
+
    async exists(filePath) {
       try {
          await fs.promises.access(filePath);

--- a/packages/core/src/implementations/setup.ts
+++ b/packages/core/src/implementations/setup.ts
@@ -81,7 +81,7 @@ export async function setupInstanceImplementation(
          output: '{@}/{workspace}/{branch}/codegen/{api_group_normalized_name}',
       },
       backups: {
-         output: '{@}/{workspace}{branch}/backups',
+         output: '{@}/{workspace}/{branch}/backups',
       },
       registry: {
          output: '{@}/registry',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -179,8 +179,9 @@ export class Caly extends TypedEmitter<EventMap> {
     * });
     * ```
     */
-   async exportBackup({ instance, workspace, branch }): Promise<Record<string, string>> {
+   async exportBackup({ instance, workspace, branch, outputDir }): Promise<Record<string, string>> {
       return exportBackupImplementation({
+         outputDir,
          instance,
          workspace,
          branch,

--- a/packages/types/src/storage/index.ts
+++ b/packages/types/src/storage/index.ts
@@ -43,7 +43,13 @@ export interface ConfigStorage {
    mkdir(path: string, options?: { recursive?: boolean }): Promise<void>;
    readdir(path: string): Promise<string[]>;
    writeFile(path: string, data: string | Uint8Array): Promise<void>;
-   streamToFile(path: string, stream: ReadableStream | NodeJS.ReadableStream): Promise<void>;
+   streamToFile({
+      path,
+      stream,
+   }: {
+      path: string;
+      stream: ReadableStream | NodeJS.ReadableStream;
+   }): Promise<void>;
    readFile(path: string): Promise<string | Uint8Array>;
    exists(path: string): Promise<boolean>;
 


### PR DESCRIPTION
- fixed a path issue, where the export path was absolute to the mount and not the project root
- fixed an issue with the output path generation
- moved the output path generation to the consumer side for the export
- added more try ... catch around the network requests
- moved away from positional arguments on backup implementation methods