### PR TITLE
chore: remove the legacy xano command

### DIFF
--- a/.changeset/cruel-rings-play.md
+++ b/.changeset/cruel-rings-play.md
@@ -1,0 +1,5 @@
+---
+"@calycode/cli": patch
+---
+
+chore: remove the legacy 'xano' command handling completely to avoid collisions with xano cli

--- a/packages/cli/esbuild.config.ts
+++ b/packages/cli/esbuild.config.ts
@@ -13,16 +13,34 @@ function defineEnvValue(name: string): string {
 }
 
 const buildEnvDefines: Record<string, string> = {
-   'process.env.CALY_BUILD_OC_EXT_DISCOVERY_MODE': defineEnvValue('CALY_BUILD_OC_EXT_DISCOVERY_MODE'),
+   'process.env.CALY_BUILD_OC_EXT_DISCOVERY_MODE': defineEnvValue(
+      'CALY_BUILD_OC_EXT_DISCOVERY_MODE',
+   ),
    'process.env.CALY_BUILD_OC_EXT_NAME': defineEnvValue('CALY_BUILD_OC_EXT_NAME'),
-   'process.env.CALY_BUILD_OC_EXT_TRUSTED_AUTHORS': defineEnvValue('CALY_BUILD_OC_EXT_TRUSTED_AUTHORS'),
-   'process.env.CALY_BUILD_OC_EXT_TRUSTED_HOMEPAGES': defineEnvValue('CALY_BUILD_OC_EXT_TRUSTED_HOMEPAGES'),
-   'process.env.CALY_BUILD_OC_EXT_TRUSTED_UPDATE_URLS': defineEnvValue('CALY_BUILD_OC_EXT_TRUSTED_UPDATE_URLS'),
-   'process.env.CALY_BUILD_OC_EXT_REQUIRE_NATIVE_MESSAGING': defineEnvValue('CALY_BUILD_OC_EXT_REQUIRE_NATIVE_MESSAGING'),
-   'process.env.CALY_BUILD_OC_EXT_PUBLIC_KEY_B64': defineEnvValue('CALY_BUILD_OC_EXT_PUBLIC_KEY_B64'),
-   'process.env.CALY_BUILD_OC_EXT_DISCOVERY_ENABLED': defineEnvValue('CALY_BUILD_OC_EXT_DISCOVERY_ENABLED'),
-   'process.env.CALY_BUILD_OC_EXT_INCLUDE_KNOWN_IDS': defineEnvValue('CALY_BUILD_OC_EXT_INCLUDE_KNOWN_IDS'),
-   'process.env.CALY_BUILD_OC_WRITE_ALL_BROWSER_MANIFESTS': defineEnvValue('CALY_BUILD_OC_WRITE_ALL_BROWSER_MANIFESTS'),
+   'process.env.CALY_BUILD_OC_EXT_TRUSTED_AUTHORS': defineEnvValue(
+      'CALY_BUILD_OC_EXT_TRUSTED_AUTHORS',
+   ),
+   'process.env.CALY_BUILD_OC_EXT_TRUSTED_HOMEPAGES': defineEnvValue(
+      'CALY_BUILD_OC_EXT_TRUSTED_HOMEPAGES',
+   ),
+   'process.env.CALY_BUILD_OC_EXT_TRUSTED_UPDATE_URLS': defineEnvValue(
+      'CALY_BUILD_OC_EXT_TRUSTED_UPDATE_URLS',
+   ),
+   'process.env.CALY_BUILD_OC_EXT_REQUIRE_NATIVE_MESSAGING': defineEnvValue(
+      'CALY_BUILD_OC_EXT_REQUIRE_NATIVE_MESSAGING',
+   ),
+   'process.env.CALY_BUILD_OC_EXT_PUBLIC_KEY_B64': defineEnvValue(
+      'CALY_BUILD_OC_EXT_PUBLIC_KEY_B64',
+   ),
+   'process.env.CALY_BUILD_OC_EXT_DISCOVERY_ENABLED': defineEnvValue(
+      'CALY_BUILD_OC_EXT_DISCOVERY_ENABLED',
+   ),
+   'process.env.CALY_BUILD_OC_EXT_INCLUDE_KNOWN_IDS': defineEnvValue(
+      'CALY_BUILD_OC_EXT_INCLUDE_KNOWN_IDS',
+   ),
+   'process.env.CALY_BUILD_OC_WRITE_ALL_BROWSER_MANIFESTS': defineEnvValue(
+      'CALY_BUILD_OC_WRITE_ALL_BROWSER_MANIFESTS',
+   ),
 };
 
 (async () => {
@@ -36,7 +54,6 @@ const buildEnvDefines: Record<string, string> = {
       const result = await build({
          entryPoints: {
             index: resolve(rootDir, 'src/index.ts'),
-            'legacy-xano': resolve(rootDir, 'src/legacy-xano-command.ts'),
          },
          bundle: true,
          platform: 'node',

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,6 @@
         "developer-tools"
     ],
     "bin": {
-        "xano": "dist/legacy-xano.cjs",
         "caly-xano": "dist/index.cjs"
     },
     "main": "dist/index.cjs",
@@ -52,7 +51,6 @@
         "commander": "^14.0.0",
         "js-yaml": "^4.1.0",
         "posthog-node": "^5.9.2",
-        "postject": "1.0.0-alpha.6",
         "shx": "^0.4.0",
         "tar": "^7.4.3"
     },
@@ -62,7 +60,7 @@
         "test:coverage": "jest --coverage",
         "clean": "trash dist tsconfig.tsbuildinfo",
         "build:js": "tsx esbuild.config.ts",
-        "build:chmod": "shx chmod +x dist/index.cjs dist/legacy-xano.cjs",
+        "build:chmod": "shx chmod +x dist/index.cjs",
         "build": "pnpm clean && pnpm build:js && pnpm build:chmod && pnpm link -g",
         "bundle:ncc": "pnpm ncc build dist/index.cjs -o dist/cli.cjs && shx cp README.md LICENSE dist/cli.cjs/",
         "bundle:sea": "tsx build-sea.ts",

--- a/packages/cli/src/legacy-xano-command.ts
+++ b/packages/cli/src/legacy-xano-command.ts
@@ -1,4 +1,0 @@
-console.error('The `xano` command is no longer provided by @calycode/cli.');
-console.error('Use `caly-xano` for CalyCode CLI commands.');
-console.error("If you want the official `xano` command, install Xano's official CLI.");
-process.exit(1);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed legacy `xano` command from CLI.
  * `caly-xano` is now the primary command-line interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->